### PR TITLE
Update freesia

### DIFF
--- a/tools/freesia/__main__.py
+++ b/tools/freesia/__main__.py
@@ -24,6 +24,7 @@ def find_needed_bytes(rom, needed_bytes, start_at):
         return 0
 
     needed_words = round_up_to_4(needed_bytes) >> 2
+    start_at = round_up_to_4(start_at)
     
     with open(rom, "rb") as rom:
         rom.seek(start_at)


### PR DESCRIPTION
I just put out a small change to `freesia` (the script responsible for finding free space) that (alongside other unimportant changes) fixes an issue when the starting location isn't word-aligned.

This PR adds that change to `bpre-unown-report`.

Edit as of 3/13: I undid the other "unimportant" changes mentioned above (which break Python 2 compatibility for no real benefit), while keeping the alignment fix.